### PR TITLE
Replace mockito-core with mockito-junit-jupiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:2.1.8.RELEASE"
     implementation "org.springframework.data:spring-data-solr:4.1.0.RELEASE"
     testCompile "org.junit.jupiter:junit-jupiter-params:5.5.2"
-    testCompile "org.mockito:mockito-core:3.1.0"
+    testCompile "org.mockito:mockito-junit-jupiter:3.1.0"
     testCompile "org.testcontainers:junit-jupiter:1.12.2"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testImplementation("org.springframework.boot:spring-boot-starter-test:2.1.8.RELEASE") {


### PR DESCRIPTION
See https://github.com/connexta/ion-ingest/pull/42. We don't currently have a need for `MockitoExtension`, but this PR will allow us to use `MockitoExtension` in the future.