### PR TITLE
Implement how polling tasks are executed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         springBootVersion = "2.2.1.RELEASE"
         springfoxSwaggerVersion = "2.9.2"
         storeApiVersion = "0.3.0"
+        transformApiVersion = "0.2.0"
     }
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -40,9 +41,11 @@ repositories {
 dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "com.connexta.transformation:transformation-api-rest-spring-stubs:${transformApiVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:1.11.613"
     implementation "com.connexta.search:index-api-rest-spring-stubs:${indexApiVersion}"
     implementation "com.connexta.store:store-api-rest-spring-stubs:${storeApiVersion}"
+    implementation "com.dyngr:polling:1.1.3"
     implementation "io.springfox:springfox-swagger2:${springfoxSwaggerVersion}"
     implementation "io.springfox:springfox-swagger-ui:${springfoxSwaggerVersion}"
     implementation "javax.inject:javax.inject:1"
@@ -106,7 +109,7 @@ dependencyCheck {
 }
 
 processResources {
-    expand([indexApiVersion: "${indexApiVersion}", storeApiVersion: "${storeApiVersion}"])
+    expand([indexApiVersion: "${indexApiVersion}", storeApiVersion: "${storeApiVersion}",  transformApiVersion: "${transformApiVersion}"])
 }
 
 bootJar {

--- a/src/main/java/com/connexta/poller/service/StatusResponse.java
+++ b/src/main/java/com/connexta/poller/service/StatusResponse.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.poller.service;
+
+public interface StatusResponse {
+
+  String getStatus();
+}

--- a/src/main/java/com/connexta/poller/service/StatusResponseImpl.java
+++ b/src/main/java/com/connexta/poller/service/StatusResponseImpl.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.poller.service;
+
+import lombok.Data;
+
+@Data
+public class StatusResponseImpl implements StatusResponse {
+
+  private final String status;
+}

--- a/src/main/java/com/connexta/poller/service/StatusService.java
+++ b/src/main/java/com/connexta/poller/service/StatusService.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.poller.service;
+
+import java.net.URI;
+
+public interface StatusService {
+
+  void submit(URI uri);
+}

--- a/src/main/java/com/connexta/poller/service/StatusServiceImpl.java
+++ b/src/main/java/com/connexta/poller/service/StatusServiceImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.poller.service;
+
+import static com.dyngr.core.AttemptResults.continueFor;
+import static com.dyngr.core.AttemptResults.finishWith;
+import static com.dyngr.core.AttemptResults.justContinue;
+
+import com.dyngr.PollerBuilder;
+import com.dyngr.core.AttemptMaker;
+import com.dyngr.core.StopStrategies;
+import com.dyngr.core.WaitStrategies;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The class's responsibilities are to manage the settings for polling and kick off new polling
+ * tasks. Other responsibilities include settings the wait and retry behavior.
+ */
+@Slf4j
+@AllArgsConstructor
+public class StatusServiceImpl implements StatusService {
+
+  @Min(0)
+  private final int secondsBetweenRetries;
+
+  @Min(1)
+  private final int secondsToLive;
+
+  @NotNull private final ExecutorService executorService;
+  @NotNull private final RestTemplate restTemplate;
+
+  @Override
+  @SuppressWarnings("unused")
+  public void submit(URI uri) {
+    StatusResponse status = null;
+    try {
+      status = poll(uri);
+    } catch (ExecutionException | InterruptedException e) {
+      log.info("Polling failed for {}", uri);
+      return;
+    }
+    process(status);
+  }
+
+  private StatusResponse poll(URI uri) throws ExecutionException, InterruptedException {
+    Future<StatusResponse> statusFuture = builder().polling(getAttemptMaker(uri)).build().start();
+    return statusFuture.get();
+  }
+
+  private AttemptMaker<StatusResponse> getAttemptMaker(URI uri) {
+    return () -> {
+      StatusResponse statusResponse = null;
+      try {
+        statusResponse = restTemplate.getForObject(uri, StatusResponse.class);
+      } catch (ResourceAccessException e) {
+        continueFor(e);
+      }
+
+      // TODO: If the transform job is done, stop polling
+      if (statusResponse != null && "complete".equalsIgnoreCase(statusResponse.getStatus())) {
+
+        // Stop polling
+        return finishWith(statusResponse);
+      }
+
+      // Job not done, keep polling
+      return justContinue();
+    };
+  }
+
+  protected void process(StatusResponse status) {
+    // TODO: Handle transformation
+  }
+
+  private PollerBuilder builder() {
+    return PollerBuilder.newBuilder()
+        .withExecutorService(executorService)
+        .stopIfException(false)
+        .withWaitStrategy(WaitStrategies.fixedWait(secondsBetweenRetries, TimeUnit.SECONDS))
+        .withStopStrategy(StopStrategies.stopAfterDelay(secondsToLive, TimeUnit.SECONDS));
+  }
+}

--- a/src/main/java/com/connexta/store/config/StoreServiceConfiguration.java
+++ b/src/main/java/com/connexta/store/config/StoreServiceConfiguration.java
@@ -6,6 +6,7 @@
  */
 package com.connexta.store.config;
 
+import com.connexta.poller.service.StatusService;
 import com.connexta.store.adaptors.StorageAdaptor;
 import com.connexta.store.clients.IndexDatasetClient;
 import com.connexta.store.service.api.StoreService;
@@ -27,9 +28,14 @@ public class StoreServiceConfiguration {
       @NotBlank @Value("${endpointUrl.retrieve}") final String retrieveEndpoint,
       @NotNull @Named("fileStorageAdaptor") final StorageAdaptor fileStorageAdapter,
       @NotNull @Named("irmStorageAdaptor") final StorageAdaptor irmStorageAdapter,
-      @NotNull final IndexDatasetClient indexDatasetClient)
+      @NotNull final IndexDatasetClient indexDatasetClient,
+      @NotNull final StatusService statusService)
       throws URISyntaxException {
     return new StoreServiceImpl(
-        new URI(retrieveEndpoint), fileStorageAdapter, irmStorageAdapter, indexDatasetClient);
+        new URI(retrieveEndpoint),
+        fileStorageAdapter,
+        irmStorageAdapter,
+        indexDatasetClient,
+        statusService);
   }
 }

--- a/src/main/java/com/connexta/store/config/TransformConfiguration.java
+++ b/src/main/java/com/connexta/store/config/TransformConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.store.config;
+
+import com.connexta.poller.service.StatusService;
+import com.connexta.poller.service.StatusServiceImpl;
+import java.util.concurrent.ExecutorService;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.support.ExecutorServiceAdapter;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class TransformConfiguration {
+  @Bean
+  public String transformApiVersion(
+      @NotBlank @Value("${endpoints.transform.version}") String transformApiVersion) {
+    return transformApiVersion;
+  }
+
+  @Bean
+  public ExecutorService threadPoolTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(32);
+    executor.setThreadNamePrefix("polling threadpool");
+    executor.initialize();
+    return new ExecutorServiceAdapter(executor);
+  }
+
+  @Bean
+  public StatusService statusService(@NotNull final ExecutorService executorService) {
+    return new StatusServiceImpl(1, 20, executorService, new RestTemplate());
+  }
+}

--- a/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
@@ -6,6 +6,7 @@
  */
 package com.connexta.store.service.impl;
 
+import com.connexta.poller.service.StatusService;
 import com.connexta.store.adaptors.FileRetrieveResponse;
 import com.connexta.store.adaptors.StorageAdaptor;
 import com.connexta.store.adaptors.StorageAdaptorRetrieveResponse;
@@ -40,6 +41,7 @@ public class StoreServiceImpl implements StoreService {
   @NotNull private final StorageAdaptor fileStorageAdaptor;
   @NotNull private final StorageAdaptor irmStorageAdaptor;
   @NotNull private final IndexDatasetClient indexDatasetClient;
+  @NotNull private final StatusService statusService;
 
   @Override
   @NotNull
@@ -52,6 +54,10 @@ public class StoreServiceImpl implements StoreService {
     final String datasetId = UUID.randomUUID().toString().replace("-", "");
     fileStorageAdaptor.store(
         fileSize, mediaType, fileInputStream, datasetId, Map.of(FILE_NAME_METADATA_KEY, fileName));
+
+    // TODO: Call the transform status service
+    // statusService.submit(uri);
+
     return UriComponentsBuilder.fromUri(retrieveUri)
         .path(StoreController.RETRIEVE_FILE_URL_TEMPLATE)
         .build(datasetId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,5 @@ endpoints:
     version: ${indexApiVersion}
   store:
     version: ${storeApiVersion}
+  transform:
+    version: ${transformApiVersion}

--- a/src/test/java/com/connexta/store/StatusServiceTest.java
+++ b/src/test/java/com/connexta/store/StatusServiceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.connexta.poller.service.StatusResponse;
+import com.connexta.poller.service.StatusResponseImpl;
+import com.connexta.poller.service.StatusService;
+import com.connexta.poller.service.StatusServiceImpl;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.web.client.HttpClientErrorException.NotFound;
+import org.springframework.web.client.RestTemplate;
+
+class StatusServiceTest {
+
+  private static URI statusUri;
+
+  @BeforeAll
+  static void beforeAll() throws URISyntaxException {
+    statusUri = new URI("http://host");
+  }
+
+  @Test
+  void testDoneOnFirstAttempt() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    doReturn(new StatusResponseImpl("complete"))
+        .when(restTemplate)
+        .getForObject(eq(statusUri), any());
+    StatusService statusService =
+        new StatusServiceImpl(1, 2, Executors.newFixedThreadPool(1), restTemplate) {
+          @Override
+          protected void process(StatusResponse status) {
+            assertThat(status.getStatus(), is("complete"));
+          }
+        };
+    statusService.submit(statusUri);
+    verify(restTemplate).getForObject(eq(statusUri), any());
+  }
+
+  @Test
+  void testInProgress() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(eq(statusUri), any()))
+        .thenReturn(new StatusResponseImpl("inprogress"))
+        .thenReturn(new StatusResponseImpl("complete"));
+    StatusService statusService =
+        new StatusServiceImpl(1, 2, Executors.newFixedThreadPool(1), restTemplate) {
+
+          @Override
+          protected void process(StatusResponse status) {
+            assertThat(status.getStatus(), is("complete"));
+          }
+        };
+    statusService.submit(statusUri);
+    verify(restTemplate, times(2)).getForObject(eq(statusUri), any());
+  }
+
+  @Test
+  @Timeout(5)
+  void testDiesOnTimeout() {
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(any(), any())).thenReturn(new StatusResponseImpl("inprogress"));
+    StatusService statusService =
+        new StatusServiceImpl(1, 2, Executors.newFixedThreadPool(1), restTemplate) {
+          @Override
+          // Polling job should be cancelled without reaching this method.
+          protected void process(StatusResponse statusResponse) {
+            fail();
+          }
+        };
+
+    statusService.submit(statusUri);
+  }
+
+  @Test
+  void testTemporaryFailure() {
+    StatusResponse response = mock(StatusResponse.class);
+    doReturn("complete").when(response).getStatus();
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    when(restTemplate.getForObject(any(), any())).thenThrow(NotFound.class).thenReturn(response);
+    StatusService statusService =
+        new StatusServiceImpl(1, 2, Executors.newFixedThreadPool(1), restTemplate) {
+
+          @Override
+          protected void process(StatusResponse status) {
+            assertThat(status.getStatus(), is("complete"));
+          }
+        };
+    statusService.submit(statusUri);
+    verify(restTemplate, times(2)).getForObject(eq(statusUri), any());
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ endpoints:
     version: testIndexApiVersion
   store:
     version: testStoreApiVersion
+  transform:
+    version: testTransformApiVersion
 s3:
   bucket:
     file: ingest-quarantine


### PR DESCRIPTION
[Ready for Review  2019-11-14T08:00]

NOTE: I had some problems with the polling thread mysteriously dying. I backed-up a few commits to where it was working and moved forward. I may have lost some changes I made in response to your comments. 

Implements how polling tasks are executed and provides a place to send requests to Store Service for promote/quarantine. Look for "TODO Follow-on ticket" for the place holders.
