### PR TITLE
Add Kubernetes deployment

### DIFF
--- a/.k8s/K8s-Deployment.md
+++ b/.k8s/K8s-Deployment.md
@@ -4,16 +4,25 @@
 To work with a K8s cluster you need to install Kubectl, a tool for controlling your K8s deployment.
 [Kubectl installation guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
+The `docker` command is the Docker Swarm equivalent to `kubectl`.
+
+By default the deploy-k8s.groovy deployment script will deploy to a local Minikube instance. To deploy to a remote
+Kubernetes cluster, you will need to add the the Docker registry environment variable `K8S_DOCKER_REGISTRY`. You
+will also need to change `kubectl`'s context to the remote one with `kubectl config use-context <remote-context>`
+
 ### Before Deploying
 Kubernetes manifests do not support adding config files directly in the manifest via a file path. Instead we need to use
 a resource called ConfigMaps.
 
 ConfigMaps are how we pass configurations to the containers. These can be created through literals or files. The only
-issue is that these can"t be created in a manifest based off a file like we used to do with Docker Compose. Now we have
-to created them manually using `kubectl create configmap <config-map-name> --from-file=<path-to-file>`
+issue is that these can't be created in a manifest based off a file like we used to do with Docker Compose. Now we have
+to created them manually using the following commands:
+- `kubectl create configmap s3-config-map --from-file=../configs/s3_config.yml`
+- `kubectl create configmap store-config-map --from-file=../configs/store_config.yml`
 
 Secret files are created in a similar fashion:
-`kubectl create secret generic --from-file=<path-to-file> <secret-name>`
+- `kubectl create secret generic s3-access-secret --from-file=../s3_access.sec`
+- `kubectl create secret generic s3-secret-secret --from-file=../s3_secret.sec`
 
 ### Deploying
 The deployment manifest file contains everything to deploy our application to the Kubernetes cluster. To deploy use:
@@ -24,12 +33,12 @@ To remove a deployment and all related pods and containers use:
 
 Note: The ConfigMap will not be deleted automatically because it was added to the cluster manually.
 #### Optional:
-Install MiniKube, a tool for running Kubernetes locally in a VM or the host
-    machine. Deploys a lightweight single-node k8s cluster.
-Note: Run `eval $(minikube docker-env)` to enter Minikube"s docker context
+Install MiniKube, a single node Kubernetes cluster that runs locally in a VM or the host machine. Deploys a lightweight single-node k8s cluster.
+Note: Run `eval $(minikube docker-env)` to point to Minikube's docker daemon. You need to do this when you build images
+for local deployment.
 
 When starting up [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), make sure your vm-driver is the one bundled with
-VirtualBox. Dnsmasq doesn"t play nice with the standalone hyperkit.
+VirtualBox. Dnsmasq doesn't play nice with the standalone hyperkit.
 
 
 ## Command Cheat Sheet
@@ -41,7 +50,7 @@ VirtualBox. Dnsmasq doesn"t play nice with the standalone hyperkit.
 - `kubectl describe` - Show detailed information about a resource
 - `kubectl logs` - Print the logs from a container in a pod
 - `kubectl exec` - Execute a command on a container in a pod
-- `kubectl exec -ti <pod_name> sh`: Starts a bash session in the pod"s container. If there"s more than one container add `--container <container_name>`
+- `kubectl exec -ti <pod_name> sh`: Starts a bash session in the pod's container. If there's more than one container add `--container <container_name>`
 - `kubectl exec <pod_name> env`: Lists environment variables
 
 The [Docker to K8s Migration Guide](https://github.com/connexta/grayskull/blob/master/kubernetes/Docker_To_Kubernetes_Guide.md#kubernetes-2)

--- a/.k8s/K8s-Deployment.md
+++ b/.k8s/K8s-Deployment.md
@@ -1,0 +1,48 @@
+# Kubernetes Deployment
+## Deployment
+### The Tool
+To work with a K8s cluster you need to install Kubectl, a tool for controlling your K8s deployment.
+[Kubectl installation guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+### Before Deploying
+Kubernetes manifests do not support adding config files directly in the manifest via a file path. Instead we need to use
+a resource called ConfigMaps.
+
+ConfigMaps are how we pass configurations to the containers. These can be created through literals or files. The only
+issue is that these can"t be created in a manifest based off a file like we used to do with Docker Compose. Now we have
+to created them manually using `kubectl create configmap <config-map-name> --from-file=<path-to-file>`
+
+Secret files are created in a similar fashion:
+`kubectl create secret generic --from-file=<path-to-file> <secret-name>`
+
+### Deploying
+The deployment manifest file contains everything to deploy our application to the Kubernetes cluster. To deploy use:
+`kubectl apply -f store-deployment.yml`
+
+To remove a deployment and all related pods and containers use:
+`kubectl delete -f store-deployment.yml`
+
+Note: The ConfigMap will not be deleted automatically because it was added to the cluster manually.
+#### Optional:
+Install MiniKube, a tool for running Kubernetes locally in a VM or the host
+    machine. Deploys a lightweight single-node k8s cluster.
+Note: Run `eval $(minikube docker-env)` to enter Minikube"s docker context
+
+When starting up [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), make sure your vm-driver is the one bundled with
+VirtualBox. Dnsmasq doesn"t play nice with the standalone hyperkit.
+
+
+## Command Cheat Sheet
+- `kubectl cluster-info`: View Cluster info
+- `kubectl get` - List resources
+    - `kubectl get nodes`: Lists available Nodes in the cluster
+    - `kubectl get pods`: Lists Pods in your cluster
+    - `kubectl get deployments`: List deployments in your cluster
+- `kubectl describe` - Show detailed information about a resource
+- `kubectl logs` - Print the logs from a container in a pod
+- `kubectl exec` - Execute a command on a container in a pod
+- `kubectl exec -ti <pod_name> sh`: Starts a bash session in the pod"s container. If there"s more than one container add `--container <container_name>`
+- `kubectl exec <pod_name> env`: Lists environment variables
+
+The [Docker to K8s Migration Guide](https://github.com/connexta/grayskull/blob/master/kubernetes/Docker_To_Kubernetes_Guide.md#kubernetes-2)
+has a lot of good info

--- a/.k8s/K8s-Deployment.md
+++ b/.k8s/K8s-Deployment.md
@@ -10,7 +10,19 @@ By default the deploy-k8s.groovy deployment script will deploy to a local Miniku
 Kubernetes cluster, you will need to add the the Docker registry environment variable `K8S_DOCKER_REGISTRY`. You
 will also need to change `kubectl`'s context to the remote one with `kubectl config use-context <remote-context>`
 
+#### Optional:
+Install MiniKube, a single node Kubernetes cluster that runs locally in a VM or the host machine. Deploys a lightweight single-node k8s cluster.
+Note: Run `eval $(minikube docker-env)` to point to Minikube's docker daemon. You need to do this when you build images
+for local deployment.
+
+When starting up [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), make sure your vm-driver is the one bundled with
+VirtualBox. Dnsmasq doesn't play nice with the standalone hyperkit.
+
 ### Before Deploying
+
+The following is for informational pruposes only. The `./gradlew deployK8s` gradle task or the `groovy deploy-k8s`
+script will do the following steps automatically.
+
 Kubernetes manifests do not support adding config files directly in the manifest via a file path. Instead we need to use
 a resource called ConfigMaps.
 
@@ -19,6 +31,7 @@ issue is that these can't be created in a manifest based off a file like we used
 to created them manually using the following commands:
 - `kubectl create configmap s3-config-map --from-file=../configs/s3_config.yml`
 - `kubectl create configmap store-config-map --from-file=../configs/store_config.yml`
+- `kubectl create configmap store-config-map --from-file=../configs/transform_config.yml`
 
 Secret files are created in a similar fashion:
 - `kubectl create secret generic s3-access-secret --from-file=../s3_access.sec`
@@ -32,14 +45,6 @@ To remove a deployment and all related pods and containers use:
 `kubectl delete -f store-deployment.yml`
 
 Note: The ConfigMap will not be deleted automatically because it was added to the cluster manually.
-#### Optional:
-Install MiniKube, a single node Kubernetes cluster that runs locally in a VM or the host machine. Deploys a lightweight single-node k8s cluster.
-Note: Run `eval $(minikube docker-env)` to point to Minikube's docker daemon. You need to do this when you build images
-for local deployment.
-
-When starting up [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), make sure your vm-driver is the one bundled with
-VirtualBox. Dnsmasq doesn't play nice with the standalone hyperkit.
-
 
 ## Command Cheat Sheet
 - `kubectl cluster-info`: View Cluster info

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -68,7 +68,7 @@ spec:
           secret:
             secretName: s3-access-secret
 
-# Exposes the store container as a service that can be reached externally
+# Exposes the store container as a service
 ---
 
 apiVersion: v1
@@ -86,7 +86,7 @@ spec:
     - port: 10051
       name: debug
 
-# Adds Ingress for communicating externally and with other services in the namespace
+# Adds Ingress to route external traffic to the store service
 ---
 
 apiVersion: extensions/v1beta1

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -18,27 +18,27 @@ spec:
     spec:
       containers:
         - name: store
-          image: ${DOCKER_REGISTRY:-docker.io}/cnxta/ion-store
+          image: cnxta/ion-store
           imagePullPolicy: Never
           volumeMounts:
             - name: store-configs
-              mountPath: /etc/config
+              mountPath: /etc/store-config
             - name: s3-configs
-              mountPath: /etc/config
+              mountPath: /etc/s3-config
             - name: s3-access
-              mountPath: /etc/secrets
+              mountPath: /etc/access-secret
             - name: s3-secret
-              mountPath: /etc/secrets
+              mountPath: /etc/secret-secret
           ports:
             - containerPort: 8080
               protocol: TCP
             - containerPort: 10051
               protocol: TCP
           args:
-            - "--s3.secret.file=/etc/secrets/s3_secret.sec"
-            - "--s3.access.file=/etc/secrets/s3_access.sec"
-            - "--spring.config.additional-location=file:/etc/config/s3_config.yml"
-            - "--spring.config.additional-location=file:/etc/config/store_config.yml"
+            - "--s3.secret.file=/etc/secret-secret/s3_secret.sec"
+            - "--s3.access.file=/etc/access-secret/s3_access.sec"
+            - "--spring.config.additional-location=file:/etc/s3-config/s3_config.yml"
+            - "--spring.config.additional-location=file:/etc/store-config/store_config.yml"
       volumes:
         - name: store-configs
           configMap:
@@ -50,12 +50,10 @@ spec:
             defaultMode: 0755
         - name: s3-secret
           secret:
-            name: s3-secret-secret
-            defaultMode: 0755
+            secretName: s3-secret-secret
         - name: s3-access
           secret:
-            name: s3-access-secret
-            defaultMode: 0755
+            secretName: s3-access-secret
 
 # Exposes the store container as a service that can be reached externally
 ---
@@ -73,5 +71,7 @@ spec:
   ports:
     - port: 8080
       nodePort: 30941
+      name: app
     - port: 10051
       nodePort: 31941
+      name: debug

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -18,8 +18,8 @@ spec:
     spec:
       containers:
         - name: store
-          image: cnxta/ion-store
-          imagePullPolicy: Never
+          image: ${registry}/cnxta/ion-store
+#          imagePullPolicy: Never
           volumeMounts:
             - name: store-configs
               mountPath: /etc/store-config
@@ -69,13 +69,42 @@ metadata:
   labels:
     app: store
 spec:
-  type: NodePort
   selector:
     app: store
   ports:
     - port: 8080
-      nodePort: 30941
       name: app
     - port: 10051
-      nodePort: 31941
       name: debug
+
+# Adds Ingress for communicating externally and with other services in the namespace
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ion-store-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      proxy_ssl_verify off;
+spec:
+  tls:
+    - hosts:
+        - ion-store.default.gsp.test
+#      secretName: elk-gsp-tls
+  rules:
+    - host: ion-store.default.gsp.test
+      http:
+        paths:
+          - backend:
+              serviceName: ion-store
+              servicePort: app
+#    - host: ion-store-debug.default.gsp.test
+#      http:
+#        paths:
+#          - backend:
+#              serviceName: ion-store
+#              servicePort: debug

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -99,10 +99,6 @@ metadata:
     nginx.ingress.kubernetes.io/server-snippet: |
       proxy_ssl_verify off;
 spec:
-  tls:
-    - hosts:
-        - ion-store.default.gsp.test
-#      secretName: elk-gsp-tls
   rules:
     - host: ion-store.default.gsp.test
       http:

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -1,6 +1,7 @@
 # Store Service deployment that creates a container for the app. It also mounts volumes for configuration and secret
-# files. The configuration files are created via manually added ConfigMaps called "store-config-map" and "s3-config-map".
-# The secret files are created manually with secret resources called "s3-secret-secret" and "s3-access-secret".
+# files. The configuration files are created via manually added ConfigMaps called "store-config-map", "s3-config-map",
+# and transform_config.yml. The secret files are created manually with secret resources called "s3-secret-secret" and
+# "s3-access-secret".
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,7 +20,7 @@ spec:
       containers:
         - name: store
           image:  registry.default.gsp.test:80/cnxta/ion-store
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           volumeMounts:
             - name: store-configs
               mountPath: /etc/store-configs

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -23,12 +23,16 @@ spec:
           volumeMounts:
             - name: store-configs
               mountPath: /etc/store-config
+              readOnly: true
             - name: s3-configs
               mountPath: /etc/s3-config
+              readOnly: true
             - name: s3-access
               mountPath: /etc/access-secret
+              readOnly: true
             - name: s3-secret
               mountPath: /etc/secret-secret
+              readOnly: true
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -18,14 +18,17 @@ spec:
     spec:
       containers:
         - name: store
-          image: ${registry}/cnxta/ion-store
-#          imagePullPolicy: Never
+          image:  registry.default.gsp.test:80/cnxta/ion-store
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: store-configs
-              mountPath: /etc/store-config
+              mountPath: /etc/store-configs
               readOnly: true
             - name: s3-configs
-              mountPath: /etc/s3-config
+              mountPath: /etc/s3-configs
+              readOnly: true
+            - name: transform-configs
+              mountPath: /etc/transform-configs
               readOnly: true
             - name: s3-access
               mountPath: /etc/access-secret
@@ -41,8 +44,9 @@ spec:
           args:
             - "--s3.secret.file=/etc/secret-secret/s3_secret.sec"
             - "--s3.access.file=/etc/access-secret/s3_access.sec"
-            - "--spring.config.additional-location=file:/etc/s3-config/s3_config.yml"
-            - "--spring.config.additional-location=file:/etc/store-config/store_config.yml"
+            - "--spring.config.additional-location=file:/etc/s3-configs/s3_config.yml"
+            - "--spring.config.additional-location=file:/etc/store-configs/store_config.yml"
+            - "--spring.config.additional-location=file:/etc/transform-configs/transform_config.yml"
       volumes:
         - name: store-configs
           configMap:
@@ -51,6 +55,10 @@ spec:
         - name: s3-configs
           configMap:
             name: s3-config-map
+            defaultMode: 0755
+        - name: transform-configs
+          configMap:
+            name: transform-config-map
             defaultMode: 0755
         - name: s3-secret
           secret:
@@ -102,9 +110,9 @@ spec:
           - backend:
               serviceName: ion-store
               servicePort: app
-#    - host: ion-store-debug.default.gsp.test
-#      http:
-#        paths:
-#          - backend:
-#              serviceName: ion-store
-#              servicePort: debug
+    - host: ion-store-debug.default.gsp.test
+      http:
+        paths:
+          - backend:
+              serviceName: ion-store
+              servicePort: debug

--- a/.k8s/store-deployment.yml
+++ b/.k8s/store-deployment.yml
@@ -1,0 +1,77 @@
+# Store Service deployment that creates a container for the app. It also mounts volumes for configuration and secret
+# files. The configuration files are created via manually added ConfigMaps called "store-config-map" and "s3-config-map".
+# The secret files are created manually with secret resources called "s3-secret-secret" and "s3-access-secret".
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: store-deployment
+  labels:
+    app: store
+spec:
+  selector:
+    matchLabels:
+      app: store
+  template:
+    metadata:
+      labels:
+        app: store
+    spec:
+      containers:
+        - name: store
+          image: ${DOCKER_REGISTRY:-docker.io}/cnxta/ion-store
+          imagePullPolicy: Never
+          volumeMounts:
+            - name: store-configs
+              mountPath: /etc/config
+            - name: s3-configs
+              mountPath: /etc/config
+            - name: s3-access
+              mountPath: /etc/secrets
+            - name: s3-secret
+              mountPath: /etc/secrets
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 10051
+              protocol: TCP
+          args:
+            - "--s3.secret.file=/etc/secrets/s3_secret.sec"
+            - "--s3.access.file=/etc/secrets/s3_access.sec"
+            - "--spring.config.additional-location=file:/etc/config/s3_config.yml"
+            - "--spring.config.additional-location=file:/etc/config/store_config.yml"
+      volumes:
+        - name: store-configs
+          configMap:
+            name: store-config-map
+            defaultMode: 0755
+        - name: s3-configs
+          configMap:
+            name: s3-config-map
+            defaultMode: 0755
+        - name: s3-secret
+          secret:
+            name: s3-secret-secret
+            defaultMode: 0755
+        - name: s3-access
+          secret:
+            name: s3-access-secret
+            defaultMode: 0755
+
+# Exposes the store container as a service that can be reached externally
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ion-store
+  labels:
+    app: store
+spec:
+  type: NodePort
+  selector:
+    app: store
+  ports:
+    - port: 8080
+      nodePort: 30941
+    - port: 10051
+      nodePort: 31941

--- a/.k8s/store_config.yml
+++ b/.k8s/store_config.yml
@@ -1,0 +1,2 @@
+endpointUrl:
+  retrieve: http://ion-store.default.gsp.test/retrieve

--- a/.k8s/store_config.yml
+++ b/.k8s/store_config.yml
@@ -1,2 +1,2 @@
 endpointUrl:
-  retrieve: http://ion-store.default.gsp.test/retrieve
+  retrieve: http://ion-store.default.gsp.test

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ docker stack deploy -c docker-compose.yml store-stack
 ### Running in the Cloud
 There are two ways to configure the build system to deploy the service to a cloud:
 - Edit the`deploy.bash` file. Set two variables near the top of the file:
-  - `SET_DOCKER_REG="ip:port"`
-  - `SET_DOCKER_W="/path/to/docker/wrapper/"`
+  - `SET_DOCKER_REG='ip:port`
+  - `SET_DOCKER_W='/path/to/docker/wrapper/'`
 
 OR
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,11 @@ task deploy(type: Exec) {
     commandLine "groovy", "deploy.groovy"
 }
 
+task deployK8s(type: Exec) {
+    dependsOn build
+    commandLine "groovy", "deploy-k8s.groovy"
+}
+
 assemble.finalizedBy("docker")
 build.finalizedBy("docker")
 bootRun.dependsOn(build)

--- a/buildSrc/src/main/groovy/SpotlessConfig.groovy
+++ b/buildSrc/src/main/groovy/SpotlessConfig.groovy
@@ -14,10 +14,6 @@ class SpotlessConfig {
             trimTrailingWhitespace()
             indentWithSpaces(4)
             endWithNewline()
-
-            //  Replace single quotes with double tickets
-            replace "Consistent quotations", "${(char) 39}", "\""
-
         }
     }
 

--- a/deploy-k8s.groovy
+++ b/deploy-k8s.groovy
@@ -1,0 +1,45 @@
+#!/usr/bin/env groovy
+//Groovy scripts throw lots of WARNING messages, but it is fine
+//https://issues.apache.org/jira/browse/GROOVY-8339
+
+def DOCKER_REG = System.getenv("K8S_DOCKER_REGISTRY") + "/"
+def DOCKER_IMAGE_NAME = "cnxta/ion-store"
+def K8S_CONTEXT = getKubeContext()
+
+
+def getKubeContext() {
+    return "kubectl config current-context".execute().text.trim()
+}
+
+def run(commands) {
+    println "Running: " + commands
+    def proc = commands.execute()
+    proc.waitForProcessOutput(System.out, System.err)
+}
+
+def header(message) {
+    println ""
+    println "# # # # # # # # # # # # # #"
+    println " " + message
+    println ""
+}
+
+header("Tagging images...")
+run("docker tag " + DOCKER_IMAGE_NAME + " " + DOCKER_REG + DOCKER_IMAGE_NAME)
+
+if (K8S_CONTEXT != "minikube") {
+    header("Pushing image to remote registry")
+    run("docker push " + DOCKER_REG + DOCKER_IMAGE_NAME)
+}
+
+header("Creating configMaps for S3 and Store Service...")
+run("kubectl create configmap s3-config-map --from-file=./configs/s3_config.yml")
+run("kubectl create configmap store-config-map --from-file=./.k8s/store_config.yml")
+run("kubectl create configmap transform-config-map --from-file=./configs/transform_config.yml")
+
+header("Creating secrets for S3")
+run("kubectl create secret generic s3-access-secret --from-file=./s3_access.sec")
+run("kubectl create secret generic s3-secret-secret --from-file=./s3_secret.sec")
+
+header("Deploying...")
+run("kubectl apply -f ./.k8s/store-deployment.yml")


### PR DESCRIPTION
[Ready for Review]
This PR gives us a Kubernetes deployment option. This will mainly be used for remote deployment, but you can deploy locally if you use Minikube as you local cluster.

Deployment is mostly automated using `./gradlew deployK8s`
In order to deploy remotely, you will need to create a `K8S_DOCKER_REGISTRY` environment variable and set `kubectl`'s context to the remote registry (see README)

This should be tested by deploying remotely on Mac, Linux, and Windows.