### PR TITLE
Implement Dataset unstaging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.39
+                minimum = 0.51
             }
         }
     }

--- a/src/main/java/com/connexta/store/adaptors/StorageAdaptorRetrieveResponse.java
+++ b/src/main/java/com/connexta/store/adaptors/StorageAdaptorRetrieveResponse.java
@@ -10,9 +10,11 @@ import java.io.InputStream;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import lombok.Generated;
 import org.springframework.http.MediaType;
 
 @Data
+@Generated
 public class StorageAdaptorRetrieveResponse {
 
   @NotNull private final MediaType mediaType;

--- a/src/main/java/com/connexta/store/controllers/StoreController.java
+++ b/src/main/java/com/connexta/store/controllers/StoreController.java
@@ -41,9 +41,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -171,10 +170,9 @@ public class StoreController implements StoreApi, IngestApi {
             message = "The requested API version is not supported and therefore not implemented.",
             response = ErrorMessage.class)
       })
-  @RequestMapping(
+  @GetMapping(
       value = StoreController.RETRIEVE_DATA_URL_TEMPLATE,
-      produces = {MediaType.APPLICATION_OCTET_STREAM_VALUE, MediaType.APPLICATION_JSON_VALUE},
-      method = RequestMethod.GET)
+      produces = {MediaType.APPLICATION_OCTET_STREAM_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<Resource> retrieveData(
       @Pattern(
               regexp =

--- a/src/main/java/com/connexta/store/service/api/StoreService.java
+++ b/src/main/java/com/connexta/store/service/api/StoreService.java
@@ -51,5 +51,17 @@ public interface StoreService {
    */
   void addMetadata(String datasetId, List<MetadataInfo> metadataInfos) throws IOException;
 
+  /**
+   * Quarantines a Dataset and prevents it from being retrieved.
+   *
+   * @param datasetId id of the Dataset
+   */
   void quarantine(String datasetId);
+
+  /**
+   * Unstages a Dataset and makes it retrievable.
+   *
+   * @param datasetId id of the Dataset
+   */
+  void unstage(String datasetId);
 }

--- a/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
@@ -227,6 +227,8 @@ public class StoreServiceImpl implements StoreService {
 
   private void verifyStoreStatus(String datasetId, StorageAdaptor adaptor) {
     String status = adaptor.getStatus(datasetId);
+    // Todo: This should also fail for "staged" statuses once staged retrieval can be locked down to
+    // only the Transformation Service
     if (!(StringUtils.equals(status, STORED) || StringUtils.equals(status, STAGED))) {
       log.info("Retrieval failed. Status for datasetId={{}} is not \"stored\".", datasetId);
       throw new RetrieveException(

--- a/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/connexta/store/service/impl/StoreServiceImpl.java
@@ -6,11 +6,15 @@
  */
 package com.connexta.store.service.impl;
 
+import static com.connexta.store.adaptors.StoreStatus.STAGED;
+import static com.connexta.store.adaptors.StoreStatus.STORED;
+
 import com.connexta.store.adaptors.StorageAdaptor;
 import com.connexta.store.adaptors.StorageAdaptorRetrieveResponse;
 import com.connexta.store.clients.IndexDatasetClient;
 import com.connexta.store.clients.TransformClient;
 import com.connexta.store.controllers.StoreController;
+import com.connexta.store.exceptions.DatasetNotFoundException;
 import com.connexta.store.exceptions.QuarantineException;
 import com.connexta.store.exceptions.RetrieveException;
 import com.connexta.store.exceptions.StoreException;
@@ -35,11 +39,11 @@ import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -73,6 +77,7 @@ public class StoreServiceImpl implements StoreService {
 
     fileStorageAdaptor.store(
         fileSize, mimeType, inputStream, datasetId, Map.of(FILE_NAME_METADATA_KEY, fileName));
+    fileStorageAdaptor.updateStatus(datasetId, STAGED);
 
     URL stagingLocation;
     try {
@@ -91,6 +96,7 @@ public class StoreServiceImpl implements StoreService {
         metacardInputStream,
         datasetId,
         Map.of());
+    metacardStorageAdaptor.updateStatus(datasetId, STAGED);
     final URL metacardLocation;
     try {
       metacardLocation =
@@ -112,15 +118,17 @@ public class StoreServiceImpl implements StoreService {
   public IonData getData(String datasetId, String dataType) {
     switch (dataType) {
       case METACARD_TYPE:
+        verifyStoreStatus(datasetId, metacardStorageAdaptor);
         InputStream metacardInputStream =
             metacardStorageAdaptor.retrieve(datasetId).getInputStream();
-
         return new IonData(
             MediaType.APPLICATION_XML_VALUE, metacardInputStream, "metacard-" + datasetId + ".xml");
       case IRM_TYPE:
+        verifyStoreStatus(datasetId, irmStorageAdaptor);
         InputStream irmInputStream = irmStorageAdaptor.retrieve(datasetId).getInputStream();
         return new IonData("application/dni-tdf+xml", irmInputStream, "irm-" + datasetId + ".xml");
       case FILE_TYPE:
+        verifyStoreStatus(datasetId, fileStorageAdaptor);
         final StorageAdaptorRetrieveResponse storageAdaptorRetrieveResponse =
             fileStorageAdaptor.retrieve(datasetId);
         final String fileName =
@@ -139,7 +147,7 @@ public class StoreServiceImpl implements StoreService {
             fileName);
       default:
         throw new IllegalArgumentException(
-            String.format("Received unsupported dataType %s", dataType));
+            String.format("Received unsupported dataType {%s}", dataType));
     }
   }
 
@@ -161,17 +169,8 @@ public class StoreServiceImpl implements StoreService {
         throw new DetailedResponseStatusException(
             HttpStatus.BAD_REQUEST, "Received invalid metadata URL received.");
       }
-
-      if (metadataResource == null) {
-        throw new DetailedResponseStatusException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "No response received for Metadata.");
-      }
-
-      Resource resource = metadataResource.getBody();
-      if (resource == null) {
-        throw new DetailedResponseStatusException(
-            HttpStatus.INTERNAL_SERVER_ERROR, "No resource received in Metadata request.");
-      }
+      Resource resource = validateMetadataResource(metadataResource);
+      unstage(datasetId);
 
       switch (dataType) {
         case METACARD_TYPE:
@@ -181,6 +180,7 @@ public class StoreServiceImpl implements StoreService {
               resource.getInputStream(),
               datasetId,
               Map.of());
+          metacardStorageAdaptor.updateStatus(datasetId, STORED);
           indexDatasetClient.indexDataset(
               datasetId,
               UriComponentsBuilder.fromUri(storeUrl)
@@ -194,6 +194,7 @@ public class StoreServiceImpl implements StoreService {
               resource.getInputStream(),
               datasetId,
               Map.of());
+          irmStorageAdaptor.updateStatus(datasetId, STORED);
           indexDatasetClient.indexDataset(
               datasetId,
               UriComponentsBuilder.fromUri(storeUrl)
@@ -202,7 +203,7 @@ public class StoreServiceImpl implements StoreService {
           break;
         default:
           throw new IllegalArgumentException(
-              String.format("Received unsupported dataType %s", dataType));
+              String.format("Received unsupported dataType {%s}", dataType));
       }
     }
   }
@@ -215,5 +216,36 @@ public class StoreServiceImpl implements StoreService {
         List.of(fileStorageAdaptor, irmStorageAdaptor, metacardStorageAdaptor)) {
       adaptor.delete(datasetId);
     }
+  }
+
+  @Override
+  public void unstage(final String datasetId) throws DatasetNotFoundException, QuarantineException {
+    fileStorageAdaptor.updateStatus(datasetId, STORED);
+    metacardStorageAdaptor.delete(datasetId);
+    log.info("Unstaged file and deleted staged metacard for datasetId={{}}", datasetId);
+  }
+
+  private void verifyStoreStatus(String datasetId, StorageAdaptor adaptor) {
+    String status = adaptor.getStatus(datasetId);
+    if (!(StringUtils.equals(status, STORED) || StringUtils.equals(status, STAGED))) {
+      log.info("Retrieval failed. Status for datasetId={{}} is not \"stored\".", datasetId);
+      throw new RetrieveException(
+          String.format("Dataset for Id={%s} has not been stored", datasetId));
+    }
+  }
+
+  @NotNull
+  private Resource validateMetadataResource(ResponseEntity<Resource> metadataResource) {
+    if (metadataResource == null) {
+      throw new DetailedResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "No response received for Metadata.");
+    }
+
+    Resource resource = metadataResource.getBody();
+    if (resource == null) {
+      throw new DetailedResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR, "No resource received in Metadata request.");
+    }
+    return resource;
   }
 }

--- a/src/test/java/com/connexta/store/adaptors/S3StorageAdaptorTests.java
+++ b/src/test/java/com/connexta/store/adaptors/S3StorageAdaptorTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2019 Connexta, LLC
+ *
+ * Released under the GNU Lesser General Public License version 3; see
+ * https://www.gnu.org/licenses/lgpl-3.0.html
+ */
+package com.connexta.store.adaptors;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.connexta.store.exceptions.QuarantineException;
+import com.connexta.store.exceptions.RetrieveException;
+import com.connexta.store.exceptions.StoreException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class S3StorageAdaptorTests {
+  private static final String BUCKET = "mr-test-bucket";
+  private static final Long FILE_SIZE = 100L;
+  private static final String MEDIA_TYPE = "text/plain";
+  private static final InputStream INPUT_STREAM = mock(InputStream.class);
+  private static final String DATASET_ID = "123e4567e89b12d3a456426655440000";
+  private static final Map<String, String> OBJECT_METADATA = Map.of("filename", "text.txt");
+
+  private static AmazonS3 mockAmazonS3;
+  private static StorageAdaptor storageAdaptor;
+
+  @BeforeAll
+  static void setUp() {
+    mockAmazonS3 = mock(AmazonS3.class);
+    storageAdaptor = new S3StorageAdaptor(mockAmazonS3, BUCKET);
+  }
+
+  @Test
+  void testStoringWhenBucketDoesNotExist() {
+    assertThrows(
+        StoreException.class,
+        () ->
+            storageAdaptor.store(FILE_SIZE, MEDIA_TYPE, INPUT_STREAM, DATASET_ID, OBJECT_METADATA));
+  }
+
+  @Test
+  void testRetrieveFailsGettingInputStream() throws IOException {
+    // given
+    S3Object mockS3Object = mock(S3Object.class);
+    InputStream mockInputStream = mock(InputStream.class);
+    when(mockAmazonS3.doesObjectExist(eq(BUCKET), anyString())).thenReturn(true);
+    when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(mockS3Object);
+    when(mockAmazonS3.doesBucketExistV2(eq(BUCKET))).thenReturn(true);
+    when(mockS3Object.getObjectContent()).thenThrow(new SdkClientException("test"));
+
+    // verify
+    assertThrows(RetrieveException.class, () -> storageAdaptor.retrieve(DATASET_ID));
+  }
+
+  @Test
+  void testRetrieveFailsGettingS3Object() throws IOException {
+    // given
+    S3Object mockS3Object = mock(S3Object.class);
+    InputStream mockInputStream = mock(InputStream.class);
+    when(mockAmazonS3.doesObjectExist(eq(BUCKET), anyString())).thenReturn(true);
+    when(mockAmazonS3.doesBucketExistV2(eq(BUCKET))).thenReturn(true);
+    when(mockAmazonS3.getObject(any(GetObjectRequest.class)))
+        .thenThrow(new SdkClientException("test"));
+
+    // verify
+    assertThrows(RetrieveException.class, () -> storageAdaptor.retrieve(DATASET_ID));
+  }
+
+  @Test
+  void testInputStreamIsAlwaysClosed() throws IOException {
+    // given
+    S3Object mockS3Object = mock(S3Object.class);
+    S3ObjectInputStream mockInputStream = mock(S3ObjectInputStream.class);
+    when(mockAmazonS3.doesObjectExist(eq(BUCKET), anyString())).thenReturn(true);
+    when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(mockS3Object);
+    when(mockAmazonS3.doesBucketExistV2(eq(BUCKET))).thenReturn(true);
+    when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
+
+    // when
+    assertThrows(RetrieveException.class, () -> storageAdaptor.retrieve(DATASET_ID));
+
+    // verify
+    verify(mockInputStream, times(1)).close();
+  }
+
+  @Test
+  void testS3ReturnsNullObject() throws IOException {
+    // given
+    S3ObjectInputStream mockInputStream = mock(S3ObjectInputStream.class);
+    when(mockAmazonS3.doesObjectExist(eq(BUCKET), anyString())).thenReturn(true);
+    when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(null);
+    when(mockAmazonS3.doesBucketExistV2(eq(BUCKET))).thenReturn(true);
+
+    // verify
+    assertThrows(RetrieveException.class, () -> storageAdaptor.retrieve(DATASET_ID));
+  }
+
+  @Test
+  void testDeleteSdkException() {
+    // given
+    AmazonS3 mockS3 = mock(AmazonS3.class);
+    when(mockS3.doesBucketExistV2(BUCKET)).thenReturn(true);
+    when(mockS3.doesObjectExist(BUCKET, DATASET_ID)).thenReturn(true);
+    doThrow(new SdkClientException("test exception")).when(mockS3).deleteObject(BUCKET, DATASET_ID);
+    StorageAdaptor sdkExceptionStorageAdaptor = new S3StorageAdaptor(mockS3, BUCKET);
+
+    // verify
+    assertThrows(QuarantineException.class, () -> sdkExceptionStorageAdaptor.delete(DATASET_ID));
+  }
+}

--- a/src/test/java/com/connexta/store/service/impl/StoreServiceImplTest.java
+++ b/src/test/java/com/connexta/store/service/impl/StoreServiceImplTest.java
@@ -6,9 +6,15 @@
  */
 package com.connexta.store.service.impl;
 
+import static com.connexta.store.adaptors.StoreStatus.QUARANTINED;
+import static com.connexta.store.adaptors.StoreStatus.STAGED;
+import static com.connexta.store.adaptors.StoreStatus.STORED;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,16 +23,26 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.connexta.store.adaptors.StorageAdaptor;
+import com.connexta.store.adaptors.StorageAdaptorRetrieveResponse;
+import com.connexta.store.adaptors.StoreStatus;
 import com.connexta.store.clients.IndexDatasetClient;
 import com.connexta.store.clients.TransformClient;
+import com.connexta.store.controllers.StoreController;
+import com.connexta.store.exceptions.DatasetNotFoundException;
 import com.connexta.store.exceptions.QuarantineException;
+import com.connexta.store.exceptions.RetrieveException;
+import com.connexta.store.exceptions.common.DetailedResponseStatusException;
 import com.connexta.store.poller.TransformStatusTask;
+import com.connexta.store.rest.models.MetadataInfo;
+import com.connexta.store.service.api.IonData;
 import com.connexta.store.service.api.StoreService;
 import com.google.common.collect.Queues;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -39,14 +55,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
 class StoreServiceImplTest {
+  private static final String DATASET_ID = "341d6c1ce5e0403a99fe86edaed66eea";
+  private static final String RESOURCE_RESPONSE =
+      "/com/connexta/store/service/impl/resourceResponse.xml";
   private StoreService storeService;
   private URI storeUrl;
   @Mock StorageAdaptor fileStorageAdaptor;
@@ -152,37 +177,244 @@ class StoreServiceImplTest {
     assertThat(task.getTransformStatusUrl(), Matchers.is(transformUrl));
   }
 
+  // Todo: Tests for adding metadata
+  @Test
+  void testAddingIrm() throws IOException {
+    var mockInputStream = mock(InputStream.class);
+    var mockResource = mock(Resource.class);
+    var mockTransformWebClient = mockWebClient(mockResource);
+    var resourceUri =
+        UriComponentsBuilder.fromUri(storeUrl)
+            .path(StoreController.RETRIEVE_DATA_URL_TEMPLATE)
+            .build(DATASET_ID, "irm");
+    var mockStoreService =
+        new StoreServiceImpl(
+            storeUrl,
+            fileStorageAdaptor,
+            irmStorageAdaptor,
+            metacardStorageAdaptor,
+            indexDatasetClient,
+            transformClient,
+            taskQueue,
+            mockTransformWebClient);
+    var metadataInfo = new MetadataInfo();
+    metadataInfo.setLocation(new URL("http://location"));
+    metadataInfo.setMetadataType("irm");
+
+    when(mockResource.getInputStream()).thenReturn(mockInputStream);
+
+    mockStoreService.addMetadata(DATASET_ID, List.of(metadataInfo));
+
+    verify(irmStorageAdaptor)
+        .store(
+            anyLong(),
+            eq(StoreController.IRM_MEDIA_TYPE_VALUE),
+            eq(mockInputStream),
+            eq(DATASET_ID),
+            eq(Map.of()));
+    verify(fileStorageAdaptor).updateStatus(eq(DATASET_ID), eq(STORED));
+    verify(metacardStorageAdaptor).delete(eq(DATASET_ID));
+    verify(irmStorageAdaptor).updateStatus(eq(DATASET_ID), eq(STORED));
+    verify(indexDatasetClient).indexDataset(DATASET_ID, resourceUri);
+  }
+
+  @Test
+  void testAddingMetacard() throws IOException {
+    var mockInputStream = mock(InputStream.class);
+    var mockResource = mock(Resource.class);
+    var mockTransformWebClient = mockWebClient(mockResource);
+    var resourceUri =
+        UriComponentsBuilder.fromUri(storeUrl)
+            .path(StoreController.RETRIEVE_DATA_URL_TEMPLATE)
+            .build(DATASET_ID, "metacard");
+    var mockStoreService =
+        new StoreServiceImpl(
+            storeUrl,
+            fileStorageAdaptor,
+            irmStorageAdaptor,
+            metacardStorageAdaptor,
+            indexDatasetClient,
+            transformClient,
+            taskQueue,
+            mockTransformWebClient);
+    var metadataInfo = new MetadataInfo();
+    metadataInfo.setLocation(new URL("http://location"));
+    metadataInfo.setMetadataType("metacard");
+
+    when(mockResource.getInputStream()).thenReturn(mockInputStream);
+
+    mockStoreService.addMetadata(DATASET_ID, List.of(metadataInfo));
+
+    verify(metacardStorageAdaptor)
+        .store(
+            anyLong(),
+            eq(MediaType.APPLICATION_XML_VALUE),
+            eq(mockInputStream),
+            eq(DATASET_ID),
+            eq(Map.of()));
+    verify(fileStorageAdaptor).updateStatus(eq(DATASET_ID), eq(STORED));
+    verify(metacardStorageAdaptor).delete(eq(DATASET_ID));
+    verify(metacardStorageAdaptor).updateStatus(eq(DATASET_ID), eq(STORED));
+    verify(indexDatasetClient).indexDataset(DATASET_ID, resourceUri);
+  }
+
+  @Test
+  void testAddingMetadataBadURL() throws IOException {
+    var metadataInfo = mock(MetadataInfo.class);
+    var mockTransformWebClient = mock(WebClient.class);
+    var uriSpecMock = mock(WebClient.RequestHeadersUriSpec.class);
+    var mockStoreService =
+        new StoreServiceImpl(
+            storeUrl,
+            fileStorageAdaptor,
+            irmStorageAdaptor,
+            metacardStorageAdaptor,
+            indexDatasetClient,
+            transformClient,
+            taskQueue,
+            mockTransformWebClient);
+
+    when(mockTransformWebClient.get()).thenReturn(uriSpecMock);
+    when(metadataInfo.getLocation()).thenReturn(new URL("http:// "));
+
+    assertThrows(
+        DetailedResponseStatusException.class,
+        () -> mockStoreService.addMetadata(DATASET_ID, List.of(metadataInfo)));
+  }
+
+  @Test
+  void testGettingBadDataType() throws IOException {
+    assertThrows(IllegalArgumentException.class, () -> storeService.getData(DATASET_ID, "badType"));
+  }
+
+  // Todo: Parameterize these tests
+  @Test
+  void testGettingIrm(
+      @Mock StorageAdaptorRetrieveResponse mockRetrieveResponse, @Mock InputStream mockInputStream)
+      throws IOException {
+    when(irmStorageAdaptor.getStatus(DATASET_ID)).thenReturn(STORED);
+    when(irmStorageAdaptor.retrieve(DATASET_ID)).thenReturn(mockRetrieveResponse);
+    when(mockRetrieveResponse.getInputStream()).thenReturn(mockInputStream);
+
+    IonData data = storeService.getData(DATASET_ID, "irm");
+
+    assertThat(data, is(notNullValue()));
+    assertThat(data.getFileName(), is("irm-" + DATASET_ID + ".xml"));
+  }
+
+  @Test
+  void testGettingMetacard(
+      @Mock StorageAdaptorRetrieveResponse mockRetrieveResponse, @Mock InputStream mockInputStream)
+      throws IOException {
+    when(metacardStorageAdaptor.getStatus(DATASET_ID)).thenReturn(STORED);
+    when(metacardStorageAdaptor.retrieve(DATASET_ID)).thenReturn(mockRetrieveResponse);
+    when(mockRetrieveResponse.getInputStream()).thenReturn(mockInputStream);
+
+    IonData data = storeService.getData(DATASET_ID, "metacard");
+
+    assertThat(data, is(notNullValue()));
+    assertThat(data.getFileName(), is("metacard-" + DATASET_ID + ".xml"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {STAGED, STORED})
+  void testGettingFile(String status) throws IOException {
+    StorageAdaptorRetrieveResponse mockRetrieveResponse =
+        mock(StorageAdaptorRetrieveResponse.class);
+    InputStream mockInputStream = mock(InputStream.class);
+    String filename = "name.txt";
+    when(fileStorageAdaptor.getStatus(DATASET_ID)).thenReturn(status);
+    when(fileStorageAdaptor.retrieve(DATASET_ID)).thenReturn(mockRetrieveResponse);
+    when(mockRetrieveResponse.getMetadata()).thenReturn(Map.of("Filename", filename));
+    when(mockRetrieveResponse.getMediaType()).thenReturn(MediaType.TEXT_PLAIN);
+    when(mockRetrieveResponse.getInputStream()).thenReturn(mockInputStream);
+
+    IonData data = storeService.getData(DATASET_ID, "file");
+
+    assertThat(data, is(notNullValue()));
+    assertThat(data.getFileName(), is(filename));
+  }
+
+  @Test
+  void testGettingDatasetNotStored() {
+    when(metacardStorageAdaptor.getStatus(eq(DATASET_ID))).thenReturn(QUARANTINED);
+
+    assertThrows(RetrieveException.class, () -> storeService.getData(DATASET_ID, "metacard"));
+    verifyNoInteractions(indexDatasetClient);
+  }
+
+  @Test
+  void testGettingDatasetNullStatus() {
+    when(metacardStorageAdaptor.getStatus(eq(DATASET_ID))).thenReturn(null);
+
+    assertThrows(RetrieveException.class, () -> storeService.getData(DATASET_ID, "metacard"));
+    verifyNoInteractions(indexDatasetClient);
+  }
+
+  @Test
+  void testSuccessfulUnstage() {
+    storeService.unstage(DATASET_ID);
+
+    verify(fileStorageAdaptor).updateStatus(DATASET_ID, StoreStatus.STORED);
+    verify(metacardStorageAdaptor).delete(DATASET_ID);
+  }
+
+  @Test
+  void testDatasetNotFoundWhenUnstaging() {
+    doThrow(new DatasetNotFoundException(""))
+        .when(fileStorageAdaptor)
+        .updateStatus(eq(DATASET_ID), eq(STORED));
+    assertThrows(DatasetNotFoundException.class, () -> storeService.unstage(DATASET_ID));
+  }
+
+  @Test
+  void testDeleteExceptionWhenUnstaging() {
+    doNothing().when(fileStorageAdaptor).updateStatus(DATASET_ID, STORED);
+    doThrow(new QuarantineException("")).when(metacardStorageAdaptor).delete(eq(DATASET_ID));
+    assertThrows(QuarantineException.class, () -> storeService.unstage(DATASET_ID));
+  }
+
   @Test
   void testSuccessfulQuarantine() {
-    String datasetId = "x";
-    storeService.quarantine(datasetId);
+    storeService.quarantine(DATASET_ID);
     for (StorageAdaptor adaptor :
         List.of(fileStorageAdaptor, irmStorageAdaptor, metacardStorageAdaptor)) {
-      verify(adaptor, times(1)).delete(datasetId);
+      verify(adaptor, times(1)).delete(DATASET_ID);
     }
   }
 
   @Test
   void testFileQuarantineException() {
-    String datasetId = "x";
-    doThrow(new QuarantineException(" ")).when(fileStorageAdaptor).delete(datasetId);
-    assertThrows(QuarantineException.class, () -> storeService.quarantine(datasetId));
+    doThrow(new QuarantineException(" ")).when(fileStorageAdaptor).delete(DATASET_ID);
+    assertThrows(QuarantineException.class, () -> storeService.quarantine(DATASET_ID));
   }
 
   @Test
   void testIrmQuarantineException() {
-    String datasetId = "x";
-    doNothing().when(fileStorageAdaptor).delete(datasetId);
-    doThrow(new QuarantineException(" ")).when(irmStorageAdaptor).delete(datasetId);
-    assertThrows(QuarantineException.class, () -> storeService.quarantine(datasetId));
+    doNothing().when(fileStorageAdaptor).delete(DATASET_ID);
+    doThrow(new QuarantineException(" ")).when(irmStorageAdaptor).delete(DATASET_ID);
+    assertThrows(QuarantineException.class, () -> storeService.quarantine(DATASET_ID));
   }
 
   @Test
   void testMetacardQuarantineException() {
-    String datasetId = "x";
-    doNothing().when(fileStorageAdaptor).delete(datasetId);
-    doNothing().when(irmStorageAdaptor).delete(datasetId);
-    doThrow(new QuarantineException(" ")).when(metacardStorageAdaptor).delete(datasetId);
-    assertThrows(QuarantineException.class, () -> storeService.quarantine(datasetId));
+    doNothing().when(fileStorageAdaptor).delete(DATASET_ID);
+    doNothing().when(irmStorageAdaptor).delete(DATASET_ID);
+    doThrow(new QuarantineException(" ")).when(metacardStorageAdaptor).delete(DATASET_ID);
+    assertThrows(QuarantineException.class, () -> storeService.quarantine(DATASET_ID));
+  }
+
+  private WebClient mockWebClient(Resource mockResource) {
+    final var mock = mock(WebClient.class);
+    final var uriSpecMock = mock(WebClient.RequestHeadersUriSpec.class);
+    final var headersSpecMock = mock(WebClient.RequestHeadersSpec.class);
+    final var responseSpecMock = mock(WebClient.ResponseSpec.class);
+    final var responseEntity = Mono.just(ResponseEntity.ok().body(mockResource));
+
+    when(mock.get()).thenReturn(uriSpecMock);
+    when(uriSpecMock.uri(any(URI.class))).thenReturn(headersSpecMock);
+    when(headersSpecMock.retrieve()).thenReturn(responseSpecMock);
+    when(responseSpecMock.toEntity(Resource.class)).thenReturn(responseEntity);
+    return mock;
   }
 }

--- a/src/test/java/com/connexta/store/service/impl/StoreServiceImplTest.java
+++ b/src/test/java/com/connexta/store/service/impl/StoreServiceImplTest.java
@@ -177,7 +177,6 @@ class StoreServiceImplTest {
     assertThat(task.getTransformStatusUrl(), Matchers.is(transformUrl));
   }
 
-  // Todo: Tests for adding metadata
   @Test
   void testAddingIrm() throws IOException {
     var mockInputStream = mock(InputStream.class);
@@ -287,7 +286,6 @@ class StoreServiceImplTest {
     assertThrows(IllegalArgumentException.class, () -> storeService.getData(DATASET_ID, "badType"));
   }
 
-  // Todo: Parameterize these tests
   @Test
   void testGettingIrm(
       @Mock StorageAdaptorRetrieveResponse mockRetrieveResponse, @Mock InputStream mockInputStream)


### PR DESCRIPTION
**[Ready For Review and Hero]**

This PR implements the unstage method in the StoreService. Unstaging the file and old metacard happens during the call to `addMetadata` in the StoreService. The file's status is updated to "stored" and the old file is deleted. The status of the requested Data in the `getData` method is verified to endure that only "stored" and "staged" Data is retrievable.

Hero steps:

1. Start up a local deployment from the `/ion-store/deployments/local`
2. Use the deploy.groovy script under the `scripts` directory to bring up a stack with the Store service and localstack.
3. Send an ingest request and verify the metacard and file status tags are "staged". 
4. Verify that they can be retrieved. (Staged Data is retrievable because Transform needs to access it. In the long term this will be locked down to just a Transformation service).
5. Send a quarantine request with the datasetId from the previous step and verify that the file and metacard are no longer retrievable.
6. Spin up an instance of the Transformation-Api service in a docker container and expose port 9090.
7. Send another ingest request and this time verify in the logs that the file is now "stored", the metacard has been deleted, and IRM has been stored. 
8. Verify that the file and IRM can be retrieved.
9 Attempting to retrieve the metacard should result in a 404.