### PR TITLE
Bump com.google.guava:guava from at least 24.1.1 to at least 28.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ ext.configArgs = [
 configurations.all {
     resolutionStrategy {
         force "com.fasterxml.jackson.core:jackson-databind:[2.10.1,)"
-        force "com.google.guava:guava:[24.1.1,)"
+        force "com.google.guava:guava:[28.1-jre,)"
     }
 }
 


### PR DESCRIPTION
I noticed that this version is out of date because dependabot doesn't update it.